### PR TITLE
First check if the actor field exists and then obtain the info

### DIFF
--- a/src/kodi/imdb.py
+++ b/src/kodi/imdb.py
@@ -105,9 +105,10 @@ def generate_imdb(id, language="en", fanart="none", fanart_file="folder.jpg", xm
                     add_node(doc, root, "genre", genre)
             else:
                 add_node(doc, root, "genre", j["genre"])
-        for actor in j["actor"]:
-            xactor = add_node(doc, root, "actor")
-            add_node(doc, xactor, "name", actor["name"])
+        if "actor" in j:
+            for actor in j["actor"]:
+                xactor = add_node(doc, root, "actor")
+                add_node(doc, xactor, "name", actor["name"])
         if "trailer" in j and "embedUrl" in j["trailer"]:
             add_node(doc, root, "trailer", "https://www.imdb.com" + j["trailer"]["embedUrl"])
         if "aggregateRating" in j and "ratingValue" in j["aggregateRating"]:


### PR DESCRIPTION
There are some movies that either don't have an actor, let say animations (https://www.imdb.com/title/tt16239222) or actors information is missing from the description (https://www.imdb.com/title/tt15328108). I encountered such issue with my collection of short films. 

I think it is purposeful to check for the existence of the 'actor' key as done with the rest fields. I tested the patch with a single actor movie (https://www.imdb.com/title/tt0073053) and it also works as I saw in the resulting .nfo; i.e., no need to distinguish the case as done in genres.